### PR TITLE
add config.alwaysObjects Update xml2json.js

### DIFF
--- a/xml2json.js
+++ b/xml2json.js
@@ -280,7 +280,7 @@
 					result = '';
 				}
 				else
-				if( result.__cnt == 1 && result.__text!=null  ) {
+				if( result.__cnt == 1 && result.__text!=null  && !config.alwaysObjects ) {
 					result = result.__text;
 				}
 				else


### PR DESCRIPTION
add a config.alwaysObjects
to parse xml elements always as object indipendently of presence of attributes/childNodes
#18
