### PR TITLE
add a config.alwaysObjects

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ The library is very small and has no any dependencies.
  * `xmlElementsFilter : []` - Filter incoming XML elements. You can pass a stringified path (like 'parent.child1.child2'), regexp or function
  * `jsonPropertiesFilter : []` - Filter JSON properties for output XML. You can pass a stringified path (like 'parent.child1.child2'), regexp or function
  * `keepCData : true|false` - If this property defined as false and an XML element has only CData node it will be converted to text without additional property "__cdata". Default is false.
+ * `alwaysObjects : true|false` - If this property defined as true and an XML element is always parsed as Object indipendently of presence of attributes. Default is false.
 
 ## Online demo
 

--- a/xml2json.js
+++ b/xml2json.js
@@ -276,7 +276,7 @@
 						delete result["#cdata-section_asArray"];
 				}
 				
-				if( result.__cnt == 0 && config.emptyNodeForm=="text" ) {
+				if( result.__cnt == 0 && config.emptyNodeForm=="text"  && !config.alwaysObjects) {
 					result = '';
 				}
 				else

--- a/xml2json.js
+++ b/xml2json.js
@@ -280,7 +280,7 @@
 					result = '';
 				}
 				else
-				if( result.__cnt == 1 && result.__text!=null  ) {
+				if( result.__cnt == 1 && result.__text!=null  && !config.alwaysObjects ) {
 					result = result.__text;
 				}
 				else

--- a/xml2json.js
+++ b/xml2json.js
@@ -284,7 +284,7 @@
 					result = result.__text;
 				}
 				else
-				if( result.__cnt == 1 && result.__cdata!=null && !config.keepCData  ) {
+				if( result.__cnt == 1 && result.__cdata!=null && !config.keepCData  && !config.alwaysObjects ) {
 					result = result.__cdata;
 				}			
 				else			


### PR DESCRIPTION
add a config.alwaysObjects #18 
to parse XML elements always as object indipendently of presence of attributes/childNodes
(sorry for the open/close duplicates... i missed something twice ;)
